### PR TITLE
Improvement: Allow setting Google Maps API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ GMAP_API=your_map_api_key_here
 
 ... or publish and edit the `filament-locationpickr-field.php` config file.
 
+> [!NOTE]  
+> You can also use the apiKey option, explained below
+
 ## Preparing the models
 
 Add a `location` column to any model migration schema used for map data
@@ -138,6 +141,7 @@ use ArberMustafa\FilamentLocationPickrField\Forms\Components\LocationPickr;
             ->clickable()
             ->height('40vh')
             ->defaultLocation([41.32836109345274, 19.818383186960773])
+            ->apiKey('GOOGLE-MAPS-API-KEY-XXXXXXXXXXX')
             ->myLocationButtonLabel('My location'),
         ....
     ]);

--- a/src/Forms/Components/LocationPickr.php
+++ b/src/Forms/Components/LocationPickr.php
@@ -27,6 +27,9 @@ class LocationPickr extends Field
 
     protected string | Closure | null $myLocationButtonLabel = null;
 
+
+    protected string | Closure $apiKey = '';
+
     private array $mapConfig = [
         'draggable' => true,
         'clickable' => false,
@@ -158,6 +161,18 @@ class LocationPickr extends Field
         return $this->evaluate($this->myLocationButtonLabel) ?? config('filament-locationpickr-field.my_location_button');
     }
 
+    public function apiKey(string | Closure $apiKey): static
+    {
+        $this->apiKey = $apiKey;
+
+        return $this;
+    }
+
+    public function getApiKey(): string
+    {
+        return $this->evaluate($this->apiKey) ?? config('filament-locationpickr-field.key');
+    }
+
     /**
      * @throws JsonException
      */
@@ -172,7 +187,7 @@ class LocationPickr extends Field
                 'controls' => $this->getMapControls(),
                 'defaultZoom' => $this->getDefaultZoom(),
                 'myLocationButtonLabel' => $this->getMyLocationButtonLabel(),
-                'apiKey' => config('filament-locationpickr-field.key'),
+                'apiKey' => $this->getApiKey(),
             ]),
             JSON_THROW_ON_ERROR
         );

--- a/src/Infolists/Components/LocationPickr.php
+++ b/src/Infolists/Components/LocationPickr.php
@@ -15,11 +15,25 @@ class LocationPickr extends Entry
 
     protected string | Closure $height = '400px';
 
+    protected string | Closure $apiKey = '';
+
     public function defaultLocation(array | Closure $defaultLocation): static
     {
         $this->defaultLocation = $defaultLocation;
 
         return $this;
+    }
+
+    public function apiKey(string|Closure $apiKey): static
+    {
+        $this->apiKey = $apiKey;
+
+        return $this;
+    }
+
+    public function getApiKey(): string
+    {
+        return $this->evaluate($this->apiKey) ?? config('filament-locationpickr-field.key');
     }
 
     public function getDefaultLocation(): array
@@ -78,7 +92,7 @@ class LocationPickr extends Entry
         return json_encode([
             'defaultLocation' => $this->getDefaultLocation(),
             'defaultZoom' => $this->getDefaultZoom(),
-            'apiKey' => config('filament-locationpickr-field.key'),
+            'apiKey' => $this->getApiKey(),
         ], JSON_THROW_ON_ERROR);
     }
 }


### PR DESCRIPTION
This commit introduces a new option, `apiKey`, to the LocationPickr field and infolist.

- This option allows developers to specify their Google Maps API key directly within the field configuration. this can be helpful when users need to use API keys dynamically, for example when the user are allowed to use there own API keys and for multi tenancy too.